### PR TITLE
Add tests for the case of reaching max recursion

### DIFF
--- a/Lib/test/lazyimports/max_recursion/__init__.py
+++ b/Lib/test/lazyimports/max_recursion/__init__.py
@@ -1,0 +1,2 @@
+from test.lazyimports.max_recursion.extern import packaging
+__import__('test.lazyimports.max_recursion.extern.packaging.markers')

--- a/Lib/test/lazyimports/max_recursion/_vendor/packaging/_compat.py
+++ b/Lib/test/lazyimports/max_recursion/_vendor/packaging/_compat.py
@@ -1,0 +1,1 @@
+string_types = (str,)

--- a/Lib/test/lazyimports/max_recursion/_vendor/packaging/_typing.py
+++ b/Lib/test/lazyimports/max_recursion/_vendor/packaging/_typing.py
@@ -1,0 +1,5 @@
+__all__ = ["TYPE_CHECKING", "cast"]
+
+TYPE_CHECKING = False
+def cast(type_, value):
+    return value

--- a/Lib/test/lazyimports/max_recursion/_vendor/packaging/markers.py
+++ b/Lib/test/lazyimports/max_recursion/_vendor/packaging/markers.py
@@ -1,0 +1,2 @@
+from ._compat import string_types
+from ._typing import TYPE_CHECKING

--- a/Lib/test/lazyimports/max_recursion/extern/__init__.py
+++ b/Lib/test/lazyimports/max_recursion/extern/__init__.py
@@ -1,0 +1,65 @@
+import sys
+
+class VendorImporter:
+    """
+    A PEP 302 meta path importer for finding optionally-vendored
+    or otherwise naturally-installed packages from root_name.
+    """
+
+    def __init__(self, root_name, vendored_names=(), vendor_pkg=None):
+        self.root_name = root_name
+        self.vendored_names = set(vendored_names)
+        self.vendor_pkg = vendor_pkg or root_name.replace('extern', '_vendor')
+
+    @property
+    def search_path(self):
+        """
+        Search first the vendor package then as a natural package.
+        """
+        yield self.vendor_pkg + '.'
+        yield ''
+
+    def find_module(self, fullname, path=None):
+        """
+        Return self when fullname starts with root_name and the
+        target module is one vendored through this importer.
+        """
+        root, base, target = fullname.partition(self.root_name + '.')
+        if root:
+            return
+        if not any(map(target.startswith, self.vendored_names)):
+            return
+        return self
+
+    def load_module(self, fullname):
+        """
+        Iterate over the search path to locate and load fullname.
+        """
+        root, base, target = fullname.partition(self.root_name + '.')
+        for prefix in self.search_path:
+            try:
+                extant = prefix + target
+                __import__(extant)
+                mod = sys.modules[extant]
+                sys.modules[fullname] = mod
+                return mod
+            except ImportError:
+                pass
+        else:
+            raise ImportError(
+                "The '{target}' package is required; "
+                "normally this is bundled with this package so if you get "
+                "this warning, consult the packager of your "
+                "distribution.".format(**locals())
+            )
+
+    def install(self):
+        """
+        Install this importer into sys.meta_path if not already present.
+        """
+        if self not in sys.meta_path:
+            sys.meta_path.append(self)
+
+
+names = 'packaging'
+VendorImporter(__name__, names).install()

--- a/Lib/test/lazyimports/reach_max_recursion.py
+++ b/Lib/test/lazyimports/reach_max_recursion.py
@@ -1,0 +1,2 @@
+from test.lazyimports import max_recursion
+max_recursion._vendor.packaging._compat

--- a/Lib/test/test_lazy_imports.py
+++ b/Lib/test/test_lazy_imports.py
@@ -77,5 +77,12 @@ class LazyImportsTest(unittest.TestCase):
         with importlib._lazy_imports(True):
             import_fresh_module("test.lazyimports.from_import_star")
 
+    def test_reach_max_recursion(self):
+        with importlib._lazy_imports(False):
+            import_fresh_module("test.lazyimports.reach_max_recursion")
+
+        with importlib._lazy_imports(True):
+            import_fresh_module("test.lazyimports.reach_max_recursion")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

# Summary
Add tests for validating the use case of reaching maximum recursion. 

# Test Plan
This use case failed on `cinder/3.10` but works in the main branch (here).

## Test in the main branch
It was covered in `test_lazy_imports.py`, so we can run the following commands to validate it. 
```
./python.exe -m test test_lazy_imports
```
or 
```
./python.exe -L -m test test_lazy_imports
```
Both results should be SUCCESS like this.
```
0:00:00 load avg: 9.85 Run tests sequentially
0:00:00 load avg: 9.85 [1/1] test_lazy_imports

== Tests result: SUCCESS ==

1 test OK.

Total duration: 143 ms
Tests result: SUCCESS
```

## Test in cinder/3.10
### Reproduce the error
If we test the same package `max_recursion` **with** Lazy Imports in `cinder/3.10`, it will show the error of **maximum recursion depth exceeded**.
```
$ ./python -L
>>> import max_recursion
>>> max_recursion._vendor.packaging._compat
<frozen importlib._bootstrap>:914: ImportWarning: VendorImporter.find_spec() not found; falling back to find_module()
<frozen importlib._bootstrap>:671: ImportWarning: VendorImporter.exec_module() not found; falling back to load_module()
Traceback (most recent call last):
  File "<frozen importlib._bootstrap>", line 1075, in _handle_fromlist
RecursionError: maximum recursion depth exceeded while calling a Python object

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
LazyImportError: Error occurred when loading a lazy import. Original import was at file /data/users/harperlin/cinder_0726/max_recursion/_vendor/packaging/markers.py, line 1
```

### Experiments with `packaging`
To analyze this use case, I tried to copy `packaging` under `extern`. That is, there will be a copied `packaging` folder in `extern`.
<img width="125" alt="image" src="https://user-images.githubusercontent.com/18440101/182250603-cbe2fd55-175f-4dfd-824a-89cf618e4665.png">
Then, I changed the code of *line 12* in `extern/__init__.py` from
```
        self.vendor_pkg = vendor_pkg or root_name.replace('extern', '_vendor')
```
to
```
        self.vendor_pkg = vendor_pkg
```
If I tested the `max_recursion` package again (replace the original `_vendor` module path with `max_recursion.extern.packaging._compat`), it won't have any error. Thus, the original code about replacing `_vendor` with `extern` in `extern/__init__.py::VendorImporter` is probably the root cause.
```
$ ./python -L
>>> import max_recursion
>>> max_recursion.extern.packaging._compat
<module 'max_recursion.extern.packaging._compat' from '/data/users/harperlin/cinder_0726/max_recursion/extern/packaging/_compat.py'>
```
