### PR TITLE
Add tests to verify `dict.items`, `dict.values` and `iter(dict)`

### DIFF
--- a/Lib/test/lazyimports/dict_values.py
+++ b/Lib/test/lazyimports/dict_values.py
@@ -1,0 +1,38 @@
+# Test the lazy imports objects are not exposed when checking the values of dictionaries
+import importlib
+from test.lazyimports.customized_modules import module
+from test.lazyimports.customized_modules.module import *
+
+g = globals().copy()
+g_copy1 = g.copy()
+g_copy2 = g.copy()
+g_copy3 = g.copy()
+g_copy4 = g.copy()
+
+def notExposeLazyPrefix(obj_repr):
+    return not obj_repr.startswith("<lazy_import ")
+
+
+# Test dict.values()
+for value in g_copy1.values():
+    assert(notExposeLazyPrefix(repr(value)))
+
+# Test dict.items()
+for key, value in g_copy2.items():
+    assert(notExposeLazyPrefix(repr(value)))
+
+# Test iter(dict.values())
+it = iter(g_copy3.values())
+for value in it:
+    assert(notExposeLazyPrefix(repr(value)))
+
+# Test iter(dict.items())
+it = iter(g_copy4.items())
+for key, value in it:
+    assert(notExposeLazyPrefix(repr(value)))
+
+# Test directly getting values by using keys
+assert(notExposeLazyPrefix(repr(g["module"])))
+assert(notExposeLazyPrefix(repr(g["sub_module1"])))
+assert(notExposeLazyPrefix(repr(g["sub_module2"])))
+assert(notExposeLazyPrefix(repr(g["sub_module3"])))

--- a/Lib/test/test_lazy_imports.py
+++ b/Lib/test/test_lazy_imports.py
@@ -120,6 +120,10 @@ class LazyImportsTest(unittest.TestCase):
         with importlib._lazy_imports(True):
             import_fresh_module("test.lazyimports.immediate_set_lazy_import_global")
 
+    def test_dict_values(self):
+        with importlib._lazy_imports(True):
+            import_fresh_module("test.lazyimports.dict_values")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

# Summary
Add tests to validate lazy imports objects are not exposed via `dict.items`, `dict.values`, and `iter(dict)`.

# Test Plan

We used `repr` to check if it leaks any prefix `<lazy_import `.
All the tests are included in `test_lazy_imports.py`, so we can run the following commands to validate the correctness.
```
$ ./python.exe -m test test_lazy_imports   
```
or 
```
$ ./python.exe -L -m test test_lazy_imports
```

The expected results are **SUCCESS** with both commands.
```
0:00:00 load avg: 2.62 Run tests sequentially
0:00:00 load avg: 2.62 [1/1] test_lazy_imports

== Tests result: SUCCESS ==

1 test OK.

Total duration: 180 ms
Tests result: SUCCESS
```