### PR TITLE
sys.getallocatedbytes()

### DIFF
--- a/Include/internal/pycore_obmalloc.h
+++ b/Include/internal/pycore_obmalloc.h
@@ -8,6 +8,7 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
+#include "pycore_atomic.h"        // _Py_atomic_int
 
 typedef unsigned int pymem_uint;  /* assuming >= 16 bits */
 
@@ -502,6 +503,7 @@ struct _obmalloc_mgmt {
     size_t narenas_highwater;
 
     Py_ssize_t raw_allocated_blocks;
+    _Py_atomic_int raw_allocated_bytes;
 };
 
 
@@ -660,6 +662,7 @@ struct _obmalloc_usage {
 struct _obmalloc_global_state {
     int dump_debug_stats;
     Py_ssize_t interpreter_leaks;
+    _Py_atomic_int interpreter_leaks_bytes;
 };
 
 struct _obmalloc_state {
@@ -685,6 +688,11 @@ extern Py_ssize_t _Py_GetGlobalAllocatedBlocks(void);
 extern Py_ssize_t _PyInterpreterState_GetAllocatedBlocks(PyInterpreterState *);
 extern void _PyInterpreterState_FinalizeAllocatedBlocks(PyInterpreterState *);
 
+extern Py_ssize_t _Py_GetGlobalAllocatedBytes(void);
+#define _Py_GetAllocatedBytes() \
+    _Py_GetGlobalAllocatedBytes()
+extern Py_ssize_t _PyInterpreterState_GetAllocatedBytes(PyInterpreterState *);
+extern void _PyInterpreterState_FinalizeAllocatedBytes(PyInterpreterState *);
 
 #ifdef WITH_PYMALLOC
 // Export the symbol for the 3rd party guppy3 project

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -64,6 +64,7 @@ extern void _PyThread_FiniType(PyInterpreterState *interp);
 extern void _Py_Deepfreeze_Fini(void);
 extern void _PyArg_Fini(void);
 extern void _Py_FinalizeAllocatedBlocks(_PyRuntimeState *);
+extern void _Py_FinalizeAllocatedBytes(_PyRuntimeState *);
 
 extern PyStatus _PyGILState_Init(PyInterpreterState *interp);
 extern PyStatus _PyGILState_SetTstate(PyThreadState *tstate);

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -997,6 +997,36 @@ class SysModuleTest(unittest.TestCase):
         c = sys.getallocatedblocks()
         self.assertIn(c, range(b - 50, b + 50))
 
+    @unittest.skipUnless(hasattr(sys, "getallocatedbytes"),
+                         "sys.getallocatedbytes unavailable on this build")
+    def test_getallocatedbytes(self):
+        a = sys.getallocatedbytes()
+        self.assertIs(type(a), int)
+        self.assertGreater(a, 0)
+        gc.collect()
+        b = sys.getallocatedbytes()
+        self.assertLessEqual(b, a)
+        # raw memory
+        o = "." * 1000000
+        z = sys.getsizeof(o)
+        gc.collect()
+        c = sys.getallocatedbytes()
+        self.assertGreater(c - b + 100, z - 100)
+        del o
+        gc.collect()
+        d = sys.getallocatedbytes()
+        self.assertGreater(c - d + 100, z - 100)
+        # small objects memory
+        o = [f"{i:^4}" for i in range(1000)]
+        z = sys.getsizeof(o) + sys.getsizeof(o[0]) * len(o)
+        gc.collect()
+        e = sys.getallocatedbytes()
+        self.assertGreater(e - d + 100, z - 100)
+        del o
+        gc.collect()
+        f = sys.getallocatedbytes()
+        self.assertGreater(e - f + 100, z - 100)
+
     def test_is_finalizing(self):
         self.assertIs(sys.is_finalizing(), False)
         # Don't use the atexit module because _Py_Finalizing is only set

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -1,6 +1,7 @@
 /* Python's malloc wrappers (see pymem.h) */
 
 #include "Python.h"
+#include "pycore_atomic.h"        // _Py_atomic_int
 #include "pycore_code.h"          // stats
 #include "pycore_pystate.h"       // _PyInterpreterState_GET
 
@@ -26,6 +27,56 @@ static void set_up_debug_hooks_unlocked(void);
 static void get_allocator_unlocked(PyMemAllocatorDomain, PyMemAllocatorEx *);
 static void set_allocator_unlocked(PyMemAllocatorDomain, PyMemAllocatorEx *);
 
+typedef struct _obmalloc_state OMState;
+
+static inline int
+has_own_state(PyInterpreterState *interp)
+{
+    return (_Py_IsMainInterpreter(interp) ||
+            !(interp->feature_flags & Py_RTFLAGS_USE_MAIN_OBMALLOC) ||
+            _Py_IsMainInterpreterFinalizing(interp));
+}
+
+static inline OMState *
+get_state(void)
+{
+    PyThreadState *tstate = _PyThreadState_GET();
+    if (tstate == NULL) {
+        return NULL;
+    }
+    PyInterpreterState *interp = tstate->interp;
+    if (!has_own_state(interp)) {
+        interp = _PyInterpreterState_Main();
+    }
+    return &interp->obmalloc;
+}
+
+static _Py_atomic_int stateless_raw_allocated_bytes;
+
+#define raw_allocated_bytes (state == NULL ? &stateless_raw_allocated_bytes : &state->mgmt.raw_allocated_bytes)
+
+
+#ifdef MS_WINDOWS
+#  include <malloc.h>
+#elif defined(__linux__)
+#  include <malloc.h>
+#elif defined(__APPLE__)
+#  include <malloc/malloc.h>
+#endif
+
+static inline size_t
+raw_malloc_size(void *p) {
+    if (p != NULL) {
+#ifdef MS_WINDOWS
+        return _msize(p);
+#elif defined(__linux__)
+        return malloc_usable_size(p);
+#elif defined(__APPLE__)
+        return malloc_size(p);
+#endif
+    }
+    return 0;
+}
 
 /***************************************/
 /* low-level allocator implementations */
@@ -40,9 +91,13 @@ _PyMem_RawMalloc(void *Py_UNUSED(ctx), size_t size)
        for malloc(0), which would be treated as an error. Some platforms would
        return a pointer with no memory behind it, which would break pymalloc.
        To solve these problems, allocate an extra byte. */
+    OMState *state = get_state();
     if (size == 0)
         size = 1;
-    return malloc(size);
+    void* ptr = malloc(size);
+    if (ptr != NULL)
+        _Py_atomic_fetch_add_relaxed(raw_allocated_bytes, raw_malloc_size(ptr));
+    return ptr;
 }
 
 void *
@@ -52,25 +107,39 @@ _PyMem_RawCalloc(void *Py_UNUSED(ctx), size_t nelem, size_t elsize)
        for calloc(0, 0), which would be treated as an error. Some platforms
        would return a pointer with no memory behind it, which would break
        pymalloc.  To solve these problems, allocate an extra byte. */
+    OMState *state = get_state();
     if (nelem == 0 || elsize == 0) {
         nelem = 1;
         elsize = 1;
     }
-    return calloc(nelem, elsize);
+    void* ptr = calloc(nelem, elsize);
+    if (ptr != NULL)
+        _Py_atomic_fetch_add_relaxed(raw_allocated_bytes, raw_malloc_size(ptr));
+    return ptr;
 }
 
 void *
 _PyMem_RawRealloc(void *Py_UNUSED(ctx), void *ptr, size_t size)
 {
+    OMState *state = get_state();
     if (size == 0)
         size = 1;
-    return realloc(ptr, size);
+    size_t oldsize = raw_malloc_size(ptr);
+    ptr = realloc(ptr, size);
+    if (ptr != NULL) {
+        _Py_atomic_fetch_add_relaxed(raw_allocated_bytes, raw_malloc_size(ptr));
+        _Py_atomic_fetch_sub_relaxed(raw_allocated_bytes, oldsize);
+    }
+    return ptr;
 }
 
 void
 _PyMem_RawFree(void *Py_UNUSED(ctx), void *ptr)
 {
+    OMState *state = get_state();
+    size_t size = raw_malloc_size(ptr);
     free(ptr);
+    _Py_atomic_fetch_sub_relaxed(raw_allocated_bytes, size);
 }
 
 #define MALLOC_ALLOC {NULL, _PyMem_RawMalloc, _PyMem_RawCalloc, _PyMem_RawRealloc, _PyMem_RawFree}
@@ -850,25 +919,6 @@ PyObject_Free(void *ptr)
 static int running_on_valgrind = -1;
 #endif
 
-typedef struct _obmalloc_state OMState;
-
-static inline int
-has_own_state(PyInterpreterState *interp)
-{
-    return (_Py_IsMainInterpreter(interp) ||
-            !(interp->feature_flags & Py_RTFLAGS_USE_MAIN_OBMALLOC) ||
-            _Py_IsMainInterpreterFinalizing(interp));
-}
-
-static inline OMState *
-get_state(void)
-{
-    PyInterpreterState *interp = _PyInterpreterState_GET();
-    if (!has_own_state(interp)) {
-        interp = _PyInterpreterState_Main();
-    }
-    return &interp->obmalloc;
-}
 
 // These macros all rely on a local "state" variable.
 #define usedpools (state->pools.used)
@@ -910,6 +960,39 @@ _PyInterpreterState_GetAllocatedBlocks(PyInterpreterState *interp)
         for (; base < (uintptr_t) allarenas[i].pool_address; base += POOL_SIZE) {
             poolp p = (poolp)base;
             n += p->ref.count;
+        }
+    }
+    return n;
+}
+
+Py_ssize_t
+_PyInterpreterState_GetAllocatedBytes(PyInterpreterState *interp)
+{
+#ifdef Py_DEBUG
+    assert(has_own_state(interp));
+#else
+    if (!has_own_state(interp)) {
+        _Py_FatalErrorFunc(__func__,
+                           "the interpreter doesn't have its own allocator");
+    }
+#endif
+    OMState *state = &interp->obmalloc;
+
+    Py_ssize_t n = _Py_atomic_load_relaxed(raw_allocated_bytes);
+    /* add up allocated bytes for used pools */
+    for (uint i = 0; i < maxarenas; ++i) {
+        /* Skip arenas which are not allocated. */
+        if (allarenas[i].address == 0) {
+            continue;
+        }
+
+        uintptr_t base = (uintptr_t)_Py_ALIGN_UP(allarenas[i].address, POOL_SIZE);
+
+        /* visit every pool in the arena */
+        assert(base <= (uintptr_t) allarenas[i].pool_address);
+        for (; base < (uintptr_t) allarenas[i].pool_address; base += POOL_SIZE) {
+            poolp p = (poolp)base;
+            n += (p->ref.count * INDEX2SIZE(p->szidx));
         }
     }
     return n;
@@ -1974,8 +2057,97 @@ _Py_FinalizeAllocatedBlocks(_PyRuntimeState *Py_UNUSED(runtime))
     return;
 }
 
+Py_ssize_t
+_PyInterpreterState_GetAllocatedBytes(PyInterpreterState *interp)
+{
+#ifdef Py_DEBUG
+    assert(has_own_state(interp));
+#else
+    if (!has_own_state(interp)) {
+        _Py_FatalErrorFunc(__func__,
+                           "the interpreter doesn't have its own allocator");
+    }
+#endif
+    OMState *state = &interp->obmalloc;
+
+    return _Py_atomic_load_relaxed(raw_allocated_bytes);
+}
+
+
 #endif /* WITH_PYMALLOC */
 
+static Py_ssize_t
+get_num_global_allocated_bytes(_PyRuntimeState *runtime)
+{
+    Py_ssize_t total = 0;
+    if (_PyRuntimeState_GetFinalizing(runtime) != NULL) {
+        PyInterpreterState *interp = _PyInterpreterState_Main();
+        if (interp == NULL) {
+            /* We are at the very end of runtime finalization.
+               We can't rely on finalizing->interp since that thread
+               state is probably already freed, so we don't worry
+               about it. */
+            assert(PyInterpreterState_Head() == NULL);
+        }
+        else {
+            assert(interp != NULL);
+            /* It is probably the last interpreter but not necessarily. */
+            assert(PyInterpreterState_Next(interp) == NULL);
+            total += _PyInterpreterState_GetAllocatedBytes(interp);
+        }
+    }
+    else {
+        HEAD_LOCK(runtime);
+        PyInterpreterState *interp = PyInterpreterState_Head();
+        assert(interp != NULL);
+#ifdef Py_DEBUG
+        int got_main = 0;
+#endif
+        for (; interp != NULL; interp = PyInterpreterState_Next(interp)) {
+#ifdef Py_DEBUG
+            if (_Py_IsMainInterpreter(interp)) {
+                assert(!got_main);
+                got_main = 1;
+                assert(has_own_state(interp));
+            }
+#endif
+            if (has_own_state(interp)) {
+                total += _PyInterpreterState_GetAllocatedBytes(interp);
+            }
+        }
+        HEAD_UNLOCK(runtime);
+#ifdef Py_DEBUG
+        assert(got_main);
+#endif
+    }
+    total += _Py_atomic_load_relaxed(&stateless_raw_allocated_bytes);
+    total += _Py_atomic_load_relaxed(&runtime->obmalloc.interpreter_leaks_bytes);
+    return total;
+}
+
+Py_ssize_t
+_Py_GetGlobalAllocatedBytes(void)
+{
+    return get_num_global_allocated_bytes(&_PyRuntime);
+}
+
+void
+_PyInterpreterState_FinalizeAllocatedBytes(PyInterpreterState *interp)
+{
+    if (has_own_state(interp)) {
+        Py_ssize_t leaked = _PyInterpreterState_GetAllocatedBytes(interp);
+        assert(has_own_state(interp) || leaked == 0);
+        _Py_atomic_fetch_add_relaxed(&interp->runtime->obmalloc.interpreter_leaks_bytes, leaked);
+    }
+}
+
+static Py_ssize_t get_num_global_allocated_bytes(_PyRuntimeState *);
+
+void
+_Py_FinalizeAllocatedBytes(_PyRuntimeState *runtime)
+{
+    _Py_atomic_store_relaxed(&runtime->obmalloc.interpreter_leaks_bytes, 0);
+}
 
 /*==========================================================================*/
 /* A x-platform debugging allocator.  This doesn't manage memory directly,

--- a/Python/clinic/sysmodule.c.h
+++ b/Python/clinic/sysmodule.c.h
@@ -912,6 +912,34 @@ exit:
     return return_value;
 }
 
+PyDoc_STRVAR(sys_getallocatedbytes__doc__,
+"getallocatedbytes($module, /)\n"
+"--\n"
+"\n"
+"Return the number of memory bytes currently allocated.");
+
+#define SYS_GETALLOCATEDBYTES_METHODDEF    \
+    {"getallocatedbytes", (PyCFunction)sys_getallocatedbytes, METH_NOARGS, sys_getallocatedbytes__doc__},
+
+static Py_ssize_t
+sys_getallocatedbytes_impl(PyObject *module);
+
+static PyObject *
+sys_getallocatedbytes(PyObject *module, PyObject *Py_UNUSED(ignored))
+{
+    PyObject *return_value = NULL;
+    Py_ssize_t _return_value;
+
+    _return_value = sys_getallocatedbytes_impl(module);
+    if ((_return_value == -1) && PyErr_Occurred()) {
+        goto exit;
+    }
+    return_value = PyLong_FromSsize_t(_return_value);
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(sys_getunicodeinternedsize__doc__,
 "getunicodeinternedsize($module, /)\n"
 "--\n"
@@ -1415,4 +1443,4 @@ exit:
 #ifndef SYS_GETANDROIDAPILEVEL_METHODDEF
     #define SYS_GETANDROIDAPILEVEL_METHODDEF
 #endif /* !defined(SYS_GETANDROIDAPILEVEL_METHODDEF) */
-/*[clinic end generated code: output=6d598acc26237fbe input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f6fb7e384dac0c13 input=a9049054013a1b77]*/

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1952,6 +1952,7 @@ Py_FinalizeEx(void)
     _Py_FinalizeRefTotal(runtime);
 #endif
     _Py_FinalizeAllocatedBlocks(runtime);
+    _Py_FinalizeAllocatedBytes(runtime);
 
 #ifdef Py_TRACE_REFS
     /* Display addresses (& refcnts) of all objects still alive.

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -966,6 +966,7 @@ PyInterpreterState_Delete(PyInterpreterState *interp)
     _PyInterpreterState_FinalizeRefTotal(interp);
 #endif
     _PyInterpreterState_FinalizeAllocatedBlocks(interp);
+    _PyInterpreterState_FinalizeAllocatedBytes(interp);
 
     HEAD_LOCK(runtime);
     PyInterpreterState **p;

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1900,6 +1900,19 @@ sys_getallocatedblocks_impl(PyObject *module)
 }
 
 /*[clinic input]
+sys.getallocatedbytes -> Py_ssize_t
+
+Return the number of memory bytes currently allocated.
+[clinic start generated code]*/
+
+static Py_ssize_t
+sys_getallocatedbytes_impl(PyObject *module)
+/*[clinic end generated code: output=0a3da1951d3cde0d input=9dd91dc935be81e9]*/
+{
+    return _Py_GetGlobalAllocatedBytes();
+}
+
+/*[clinic input]
 sys.getunicodeinternedsize -> Py_ssize_t
 
 Return the number of elements of the unicode interned dictionary
@@ -2360,6 +2373,7 @@ static PyMethodDef sys_methods[] = {
     SYS_GETDEFAULTENCODING_METHODDEF
     SYS_GETDLOPENFLAGS_METHODDEF
     SYS_GETALLOCATEDBLOCKS_METHODDEF
+    SYS_GETALLOCATEDBYTES_METHODDEF
     SYS_GETUNICODEINTERNEDSIZE_METHODDEF
     SYS_GETFILESYSTEMENCODING_METHODDEF
     SYS_GETFILESYSTEMENCODEERRORS_METHODDEF

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -318,6 +318,7 @@ Objects/obmalloc.c	-	_PyMem_Debug	-
 Objects/obmalloc.c	-	_PyMem_Raw	-
 Objects/obmalloc.c	-	_PyObject	-
 Objects/obmalloc.c	-	last_final_leaks	-
+Objects/obmalloc.c	-	stateless_raw_allocated_bytes	-
 Objects/obmalloc.c	-	usedpools	-
 Objects/typeobject.c	-	name_op	-
 Objects/typeobject.c	-	slotdefs	-


### PR DESCRIPTION
### sys.getallocatedbytes()

This implements `sys.getallocatedbytes()` using atomics to track memory in the raw allocator as well.